### PR TITLE
1.ApiInterceptor设置Subject新增tokenStorageLimit属性：单用户token存储条数限制，以解决redi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>JwtPermission</groupId>
 	<artifactId>JwtPermission</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.2.2</version>
 	<name>JwtPermission</name>
 
 	<dependencies>

--- a/src/main/java/com/wf/etp/authz/ApiInterceptor.java
+++ b/src/main/java/com/wf/etp/authz/ApiInterceptor.java
@@ -38,6 +38,10 @@ public class ApiInterceptor implements HandlerInterceptor {
 		SubjectUtil.getInstance().setDebug(debug);
 	}
 
+	public void setTokenStorageLimit(int tokenStorageLimit) {
+		SubjectUtil.getInstance().setTokenStorageLimit(tokenStorageLimit);
+	}
+
 	@Override
 	public void afterCompletion(HttpServletRequest request,
 			HttpServletResponse response, Object handler, Exception ex)
@@ -53,10 +57,10 @@ public class ApiInterceptor implements HandlerInterceptor {
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
 		SubjectUtil subjectUtil = SubjectUtil.getInstance();
-		
+
 		String token = subjectUtil.getRequestToken(request);
 		String userId = subjectUtil.parseToken(token).getSubject();
-		
+
 		// 检查权限
 		if (handler instanceof HandlerMethod) {
 			Method method = ((HandlerMethod) handler).getMethod();

--- a/src/main/java/com/wf/etp/authz/IEtpCache.java
+++ b/src/main/java/com/wf/etp/authz/IEtpCache.java
@@ -18,6 +18,9 @@ public abstract class IEtpCache {
 	// 把集合加入缓存
 	public abstract boolean putSet(String key, Set<String> values);
 
+	// 把单条数据加入缓存
+	public abstract boolean putSet(String key, String value);
+
 	// 删除集合的某一元素
 	public abstract boolean removeSet(String key, String value);
 

--- a/src/main/java/com/wf/etp/authz/IUserRealm.java
+++ b/src/main/java/com/wf/etp/authz/IUserRealm.java
@@ -31,7 +31,12 @@ public abstract class IUserRealm {
 	 * 
 	 * @return
 	 */
-	public boolean isSingleUser() {
-		return false;
-	}
+	public abstract boolean isSingleUser();
+
+	/**
+	 * 单点登录是否有下线通知,在单点模式下生效
+	 *
+	 * @return
+	 */
+	public abstract boolean hasDownlineTip();
 }

--- a/src/main/java/com/wf/etp/authz/SubjectUtil.java
+++ b/src/main/java/com/wf/etp/authz/SubjectUtil.java
@@ -216,10 +216,10 @@ public class SubjectUtil {
 		List<String> tokens = cache.getSet(KEY_PRE_TOKEN + userId);
 		if (tokens != null && tokens.contains(token)){
 			if (userRealm.isSingleUser() && !token.equals(tokens.get(0)) ){
-				expireToken(userId,token);
 				if(userRealm.hasDownlineTip()){
 					throw new DownlineException();
 				}else{
+					expireToken(userId,token);
 					throw new ExpiredTokenException();
 				}
 			}

--- a/src/main/java/com/wf/etp/authz/SubjectUtil.java
+++ b/src/main/java/com/wf/etp/authz/SubjectUtil.java
@@ -215,10 +215,12 @@ public class SubjectUtil {
 		checkUserRealm();
 		List<String> tokens = cache.getSet(KEY_PRE_TOKEN + userId);
 		if (tokens != null && tokens.contains(token)){
-			if (userRealm.isSingleUser() && userRealm.hasDownlineTip()){
-				if( !token.equals(tokens.get(0))){
-					expireToken(userId,token);
+			if (userRealm.isSingleUser() && !token.equals(tokens.get(0)) ){
+				expireToken(userId,token);
+				if(userRealm.hasDownlineTip()){
 					throw new DownlineException();
+				}else{
+					throw new ExpiredTokenException();
 				}
 			}
 		}else{

--- a/src/main/java/com/wf/etp/authz/TokenUtil.java
+++ b/src/main/java/com/wf/etp/authz/TokenUtil.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.impl.Base64Codec;
+import org.springframework.util.StringUtils;
 
 import java.security.Key;
 import java.util.Date;
@@ -53,7 +54,7 @@ public class TokenUtil {
 	 * @throws Exception
 	 */
 	protected static Claims parseToken(String token, String key) throws Exception {
-		if (token == null) {
+		if (StringUtils.isEmpty(token)) {
 			throw new NullPointerException("token不能为null");
 		}
 		return Jwts.parser().setSigningKey(generalKey(key))

--- a/src/main/java/com/wf/etp/authz/exception/DownlineException.java
+++ b/src/main/java/com/wf/etp/authz/exception/DownlineException.java
@@ -1,0 +1,15 @@
+package com.wf.etp.authz.exception;
+
+public class DownlineException extends EtpException {
+
+    private static final long serialVersionUID = -5163940850688796162L;
+
+    public DownlineException() {
+        super(402, "token被迫下线通知");
+    }
+
+    public DownlineException(String message) {
+        super(402, message);
+    }
+
+}


### PR DESCRIPTION
…s无限存储的隐患,默认值10条

2.删除expairBadToken()方法，该方法会导致内存高危，由于tokenStorageLimit的有限和token有序存储，可无需删除redis过期token
3.新增IUserRealm的isSingleUser()和hasDownlineTip()两个抽象方法，以实现单点登录及单点登录简单的被迫下线提示
4.新增DownlineException异常提示错误码402：token被迫下线